### PR TITLE
Add basic authentication templates

### DIFF
--- a/GestionLocativ/GestionLocativ.Client/Layout/NavMenu.razor
+++ b/GestionLocativ/GestionLocativ.Client/Layout/NavMenu.razor
@@ -1,10 +1,33 @@
 ﻿
+@inject AuthService Auth
+@inject NavigationManager Nav
+
 <MudNavMenu>
     <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
     <MudNavLink Href="counter" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Add">Counter</MudNavLink>
-    
     <MudNavLink Href="weather" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Weather</MudNavLink>
 
+    @if (Auth.IsAuthenticated)
+    {
+        <MudNavLink Href="dashboard" Icon="@Icons.Material.Filled.Dashboard">Dashboard</MudNavLink>
+        <MudNavLink Href="tenants" Icon="@Icons.Material.Filled.Group">Tenants</MudNavLink>
+        <MudNavLink Href="maintenance" Icon="@Icons.Material.Filled.Build">Maintenance</MudNavLink>
+        <MudNavLink Href="utilities" Icon="@Icons.Material.Filled.Receipt">Utilities</MudNavLink>
+        <MudNavLink Href="" OnClick="Logout" Icon="@Icons.Material.Filled.Logout">Logout</MudNavLink>
+    }
+    else
+    {
+        <MudNavLink Href="login" Icon="@Icons.Material.Filled.Lock">Login</MudNavLink>
+    }
+
 </MudNavMenu>
+
+@code {
+    private void Logout()
+    {
+        Auth.Logout();
+        Nav.NavigateTo("login", true);
+    }
+}
 
 

--- a/GestionLocativ/GestionLocativ.Client/Pages/Dashboard.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/Dashboard.razor
@@ -1,0 +1,24 @@
+@page "/dashboard"
+
+@inject AuthService Auth
+@inject NavigationManager Nav
+
+@if (Auth.IsAuthenticated)
+{
+    <MudText Typo="Typo.h4" Class="mb-4">Dashboard</MudText>
+    <MudList>
+        <MudListItem Href="tenants">Tenants</MudListItem>
+        <MudListItem Href="maintenance">Maintenance</MudListItem>
+        <MudListItem Href="utilities">Utilities</MudListItem>
+    </MudList>
+}
+
+@code {
+    protected override void OnInitialized()
+    {
+        if (!Auth.IsAuthenticated)
+        {
+            Nav.NavigateTo("/login", true);
+        }
+    }
+}

--- a/GestionLocativ/GestionLocativ.Client/Pages/Login.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/Login.razor
@@ -1,0 +1,26 @@
+@page "/login"
+
+@inject AuthService Auth
+@inject NavigationManager Nav
+
+<MudPaper Class="pa-6 mx-auto mt-12" Style="max-width:400px;">
+    <MudText Typo="Typo.h5" Class="mb-4">Login</MudText>
+    <MudTextField @bind-Value="_user" Label="User" Variant="Variant.Filled" Class="mb-4" />
+    <MudTextField @bind-Value="_password" Label="Password" Variant="Variant.Filled" InputType="InputType.Password" Class="mb-4" />
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="OnLogin" FullWidth="true" Class="mb-4">Login</MudButton>
+    <MudStack Row="true" Justify="space-between">
+        <MudLink Href="register">Register</MudLink>
+        <MudLink Href="reset">Forgot password?</MudLink>
+    </MudStack>
+</MudPaper>
+
+@code {
+    private string _user = string.Empty;
+    private string _password = string.Empty;
+
+    private void OnLogin()
+    {
+        Auth.Login(_user, _password);
+        Nav.NavigateTo("/dashboard", true);
+    }
+}

--- a/GestionLocativ/GestionLocativ.Client/Pages/Maintenance.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/Maintenance.razor
@@ -1,0 +1,40 @@
+@page "/maintenance"
+
+@inject AuthService Auth
+@inject NavigationManager Nav
+
+@if (Auth.IsAuthenticated)
+{
+    <MudText Typo="Typo.h4" Class="mb-4">Maintenance</MudText>
+    <MudTextField @bind-Value="_description" Label="Description" Variant="Variant.Filled" Class="mb-4" />
+    <MudButton Variant="Variant.Filled" OnClick="AddMaintenance">Add Maintenance</MudButton>
+
+    <MudList Class="mt-4">
+        @foreach (var item in _items)
+        {
+            <MudListItem>@item</MudListItem>
+        }
+    </MudList>
+}
+
+@code {
+    private string _description = string.Empty;
+    private List<string> _items = new();
+
+    protected override void OnInitialized()
+    {
+        if (!Auth.IsAuthenticated)
+        {
+            Nav.NavigateTo("/login", true);
+        }
+    }
+
+    private void AddMaintenance()
+    {
+        if (!string.IsNullOrWhiteSpace(_description))
+        {
+            _items.Add(_description);
+            _description = string.Empty;
+        }
+    }
+}

--- a/GestionLocativ/GestionLocativ.Client/Pages/Register.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/Register.razor
@@ -1,0 +1,24 @@
+@page "/register"
+
+@inject NavigationManager Nav
+@inject AuthService Auth
+
+<MudPaper Class="pa-6 mx-auto mt-12" Style="max-width:400px;">
+    <MudText Typo="Typo.h5" Class="mb-4">Register</MudText>
+    <MudTextField @bind-Value="_user" Label="User" Variant="Variant.Filled" Class="mb-4" />
+    <MudTextField @bind-Value="_password" Label="Password" Variant="Variant.Filled" InputType="InputType.Password" Class="mb-4" />
+    <MudTextField @bind-Value="_confirm" Label="Confirm Password" Variant="Variant.Filled" InputType="InputType.Password" Class="mb-4" />
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="OnRegister" FullWidth="true">Register</MudButton>
+</MudPaper>
+
+@code {
+    private string _user = string.Empty;
+    private string _password = string.Empty;
+    private string _confirm = string.Empty;
+
+    private void OnRegister()
+    {
+        Auth.Register(_user, _password);
+        Nav.NavigateTo("/dashboard", true);
+    }
+}

--- a/GestionLocativ/GestionLocativ.Client/Pages/ResetPassword.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/ResetPassword.razor
@@ -1,0 +1,20 @@
+@page "/reset"
+
+@inject NavigationManager Nav
+@inject AuthService Auth
+
+<MudPaper Class="pa-6 mx-auto mt-12" Style="max-width:400px;">
+    <MudText Typo="Typo.h5" Class="mb-4">Reset Password</MudText>
+    <MudTextField @bind-Value="_email" Label="Email" Variant="Variant.Filled" Class="mb-4" />
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="OnReset" FullWidth="true">Send reset link</MudButton>
+</MudPaper>
+
+@code {
+    private string _email = string.Empty;
+
+    private void OnReset()
+    {
+        Auth.ResetPassword(_email);
+        Nav.NavigateTo("/login", true);
+    }
+}

--- a/GestionLocativ/GestionLocativ.Client/Pages/Tenants.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/Tenants.razor
@@ -1,0 +1,49 @@
+@page "/tenants"
+
+@inject AuthService Auth
+@inject NavigationManager Nav
+
+@if (Auth.IsAuthenticated)
+{
+    <MudText Typo="Typo.h4" Class="mb-4">Tenants</MudText>
+    <MudTextField @bind-Value="_name" Label="Tenant Name" Variant="Variant.Filled" Class="mb-4" />
+    <MudTextField @bind-Value="_client" Label="Associated Client" Variant="Variant.Filled" Class="mb-4" />
+    <MudButton Variant="Variant.Filled" OnClick="AddTenant">Add Tenant</MudButton>
+
+    <MudList Class="mt-4">
+        @foreach (var t in _tenants)
+        {
+            <MudListItem>@t.Name - @t.Client</MudListItem>
+        }
+    </MudList>
+}
+
+@code {
+    private string _name = string.Empty;
+    private string _client = string.Empty;
+    private List<Tenant> _tenants = new();
+
+    protected override void OnInitialized()
+    {
+        if (!Auth.IsAuthenticated)
+        {
+            Nav.NavigateTo("/login", true);
+        }
+    }
+
+    private void AddTenant()
+    {
+        if (!string.IsNullOrWhiteSpace(_name))
+        {
+            _tenants.Add(new Tenant { Name = _name, Client = _client });
+            _name = string.Empty;
+            _client = string.Empty;
+        }
+    }
+
+    private class Tenant
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Client { get; set; } = string.Empty;
+    }
+}

--- a/GestionLocativ/GestionLocativ.Client/Pages/Utilities.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/Utilities.razor
@@ -1,0 +1,41 @@
+@page "/utilities"
+
+@inject AuthService Auth
+@inject NavigationManager Nav
+
+@if (Auth.IsAuthenticated)
+{
+    <MudText Typo="Typo.h4" Class="mb-4">Utilities</MudText>
+    <MudTextField @bind-Value="_water" Label="Water Bill" Variant="Variant.Filled" Class="mb-4" />
+    <MudTextField @bind-Value="_electric" Label="Electricity Bill" Variant="Variant.Filled" Class="mb-4" />
+    <MudButton Variant="Variant.Filled" OnClick="AddUtility">Add</MudButton>
+
+    <MudList Class="mt-4">
+        @foreach (var item in _items)
+        {
+            <MudListItem>@item</MudListItem>
+        }
+    </MudList>
+}
+
+@code {
+    private string _water = string.Empty;
+    private string _electric = string.Empty;
+    private List<string> _items = new();
+
+    protected override void OnInitialized()
+    {
+        if (!Auth.IsAuthenticated)
+        {
+            Nav.NavigateTo("/login", true);
+        }
+    }
+
+    private void AddUtility()
+    {
+        var info = $"Water: {_water}, Electric: {_electric}";
+        _items.Add(info);
+        _water = string.Empty;
+        _electric = string.Empty;
+    }
+}

--- a/GestionLocativ/GestionLocativ.Client/Program.cs
+++ b/GestionLocativ/GestionLocativ.Client/Program.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
+using GestionLocativ.Client.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
 builder.Services.AddMudServices();
+builder.Services.AddSingleton<AuthService>();
 
 await builder.Build().RunAsync();

--- a/GestionLocativ/GestionLocativ.Client/Services/AuthService.cs
+++ b/GestionLocativ/GestionLocativ.Client/Services/AuthService.cs
@@ -1,0 +1,34 @@
+namespace GestionLocativ.Client.Services
+{
+    public class AuthService
+    {
+        public bool IsAuthenticated { get; private set; }
+
+        public event Action? AuthenticationStateChanged;
+
+        public void Login(string user, string password)
+        {
+            // In a real app, validate credentials here
+            IsAuthenticated = true;
+            AuthenticationStateChanged?.Invoke();
+        }
+
+        public void Register(string user, string password)
+        {
+            // Registration logic would go here
+            IsAuthenticated = true;
+            AuthenticationStateChanged?.Invoke();
+        }
+
+        public void ResetPassword(string email)
+        {
+            // Send reset email in a real app
+        }
+
+        public void Logout()
+        {
+            IsAuthenticated = false;
+            AuthenticationStateChanged?.Invoke();
+        }
+    }
+}

--- a/GestionLocativ/GestionLocativ.Client/_Imports.razor
+++ b/GestionLocativ/GestionLocativ.Client/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using MudBlazor
 @using MudBlazor.Services
+@using GestionLocativ.Client.Services

--- a/GestionLocativ/GestionLocativ/Program.cs
+++ b/GestionLocativ/GestionLocativ/Program.cs
@@ -1,11 +1,13 @@
 using MudBlazor.Services;
 using GestionLocativ.Client.Pages;
+using GestionLocativ.Client.Services;
 using GestionLocativ.Components;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add MudBlazor services
 builder.Services.AddMudServices();
+builder.Services.AddSingleton<AuthService>();
 
 // Add services to the container.
 builder.Services.AddRazorComponents()


### PR DESCRIPTION
## Summary
- add simple `AuthService` to manage authentication state
- register `AuthService` in server and client `Program.cs`
- create login, register, reset password, and dashboard pages
- add tenant, maintenance and utilities pages for dashboard management
- update nav menu to show links based on authentication
- include service namespace in `_Imports.razor`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844909e11d88320b937c2542a8f7c24