### PR TITLE
Fix justify property on login page

### DIFF
--- a/GestionLocativ/GestionLocativ.Client/Pages/Login.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/Login.razor
@@ -8,7 +8,7 @@
     <MudTextField @bind-Value="_user" Label="User" Variant="Variant.Filled" Class="mb-4" />
     <MudTextField @bind-Value="_password" Label="Password" Variant="Variant.Filled" InputType="InputType.Password" Class="mb-4" />
     <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="OnLogin" FullWidth="true" Class="mb-4">Login</MudButton>
-    <MudStack Row="true" Justify="space-between">
+    <MudStack Row="true" Justify="Justify.SpaceBetween">
         <MudLink Href="register">Register</MudLink>
         <MudLink Href="reset">Forgot password?</MudLink>
     </MudStack>


### PR DESCRIPTION
## Summary
- correct MudStack Justify prop usage in `Login.razor`

## Testing
- `dotnet build GestionLocativ/GestionLocativ.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844957e1990832098845ec3c6d48d6c