### PR TITLE
Add generics to MudList controls

### DIFF
--- a/GestionLocativ/GestionLocativ.Client/Pages/Dashboard.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/Dashboard.razor
@@ -6,10 +6,10 @@
 @if (Auth.IsAuthenticated)
 {
     <MudText Typo="Typo.h4" Class="mb-4">Dashboard</MudText>
-    <MudList>
-        <MudListItem Href="tenants">Tenants</MudListItem>
-        <MudListItem Href="maintenance">Maintenance</MudListItem>
-        <MudListItem Href="utilities">Utilities</MudListItem>
+    <MudList T="string">
+        <MudListItem T="string" Href="tenants">Tenants</MudListItem>
+        <MudListItem T="string" Href="maintenance">Maintenance</MudListItem>
+        <MudListItem T="string" Href="utilities">Utilities</MudListItem>
     </MudList>
 }
 

--- a/GestionLocativ/GestionLocativ.Client/Pages/Maintenance.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/Maintenance.razor
@@ -9,10 +9,10 @@
     <MudTextField @bind-Value="_description" Label="Description" Variant="Variant.Filled" Class="mb-4" />
     <MudButton Variant="Variant.Filled" OnClick="AddMaintenance">Add Maintenance</MudButton>
 
-    <MudList Class="mt-4">
+    <MudList T="string" Class="mt-4">
         @foreach (var item in _items)
         {
-            <MudListItem>@item</MudListItem>
+            <MudListItem T="string">@item</MudListItem>
         }
     </MudList>
 }

--- a/GestionLocativ/GestionLocativ.Client/Pages/Tenants.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/Tenants.razor
@@ -10,10 +10,10 @@
     <MudTextField @bind-Value="_client" Label="Associated Client" Variant="Variant.Filled" Class="mb-4" />
     <MudButton Variant="Variant.Filled" OnClick="AddTenant">Add Tenant</MudButton>
 
-    <MudList Class="mt-4">
+    <MudList T="Tenant" Class="mt-4">
         @foreach (var t in _tenants)
         {
-            <MudListItem>@t.Name - @t.Client</MudListItem>
+            <MudListItem T="Tenant">@t.Name - @t.Client</MudListItem>
         }
     </MudList>
 }

--- a/GestionLocativ/GestionLocativ.Client/Pages/Utilities.razor
+++ b/GestionLocativ/GestionLocativ.Client/Pages/Utilities.razor
@@ -10,10 +10,10 @@
     <MudTextField @bind-Value="_electric" Label="Electricity Bill" Variant="Variant.Filled" Class="mb-4" />
     <MudButton Variant="Variant.Filled" OnClick="AddUtility">Add</MudButton>
 
-    <MudList Class="mt-4">
+    <MudList T="string" Class="mt-4">
         @foreach (var item in _items)
         {
-            <MudListItem>@item</MudListItem>
+            <MudListItem T="string">@item</MudListItem>
         }
     </MudList>
 }


### PR DESCRIPTION
## Summary
- specify `T="string"` for `MudList` in Dashboard, Maintenance and Utilities pages
- specify `T="Tenant"` for `MudList` in Tenants page
- update each `MudListItem` with matching generics

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844957953348320bf26176ed91a954d